### PR TITLE
fix(docs) Updates copyright, maintainer email, issues_url

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,6 +1,6 @@
 name 'chef-lacework'
 maintainer 'Lacework, Inc.'
-maintainer_email 'humans@lacework.net'
+maintainer_email 'tech-ally@lacework.net'
 license 'All Rights Reserved'
 description 'Installs/Configures chef-lacework'
 version '0.1.0'
@@ -13,10 +13,10 @@ end
 # tracked.  A `View Issues` link will be displayed on this cookbook's page when
 # uploaded to a Supermarket.
 #
-issues_url 'https://github.com/scottford-lw/chef-lacework/issues'
+issues_url 'https://github.com/lacework/chef-lacework/issues'
 
 # The `source_url` points to the development repository for this cookbook.  A
 # `View Source` link will be displayed on this cookbook's page when uploaded to
 # a Supermarket.
 #
-source_url 'https://github.com/scottford-lw/chef-lacework'
+source_url 'https://github.com/lacework/chef-lacework'

--- a/recipes/_apt.rb
+++ b/recipes/_apt.rb
@@ -2,7 +2,7 @@
 # Cookbook:: chef-lacework
 # Recipe:: _apt
 #
-# Copyright:: 2020, The Authors, All Rights Reserved.
+# Copyright:: 2020, Lacework, All Rights Reserved.
 case node['platform']
 when 'ubuntu'
   apt_repository 'packages-lacework-prod' do

--- a/recipes/_deb.rb
+++ b/recipes/_deb.rb
@@ -2,7 +2,7 @@
 # Cookbook:: chef-lacework
 # Recipe:: _deb
 #
-# Copyright:: 2020, The Authors, All Rights Reserved.
+# Copyright:: 2020, Lacework, All Rights Reserved.
 remote_file "#{node['chef-lacework']['package_dir']}/#{node['chef-lacework']['deb_package']['package_name']}" do
   source node['chef-lacework']['deb_package']['url']
 end

--- a/recipes/_rpm.rb
+++ b/recipes/_rpm.rb
@@ -2,7 +2,7 @@
 # Cookbook:: chef-lacework
 # Recipe:: _rpm
 #
-# Copyright:: 2020, The Authors, All Rights Reserved.
+# Copyright:: 2020, Lacework, All Rights Reserved.
 
 remote_file "#{node['chef-lacework']['package_dir']}/#{node['chef-lacework']['rpm_package']['package_name']}" do
   source node['chef-lacework']['rpm_package']['url']

--- a/recipes/_script.rb
+++ b/recipes/_script.rb
@@ -2,7 +2,7 @@
 # Cookbook:: chef-lacework
 # Recipe:: _script
 #
-# Copyright:: 2020, The Authors, All Rights Reserved.
+# Copyright:: 2020, Lacework, All Rights Reserved.
 remote_file "#{node['chef-lacework']['install_script']['dir']}/install.sh" do
   source 'https://packages.lacework.net/install.sh'
   mode '0500'

--- a/recipes/_yum.rb
+++ b/recipes/_yum.rb
@@ -2,7 +2,7 @@
 # Cookbook:: chef-lacework
 # Recipe:: _yum
 #
-# Copyright:: 2020, The Authors, All Rights Reserved.
+# Copyright:: 2020, Lacework, All Rights Reserved.
 yum_repository 'packages-lacework-prod' do
   action :create
   baseurl 'https://packages.lacework.net/RPMS/x86_64'

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -2,7 +2,7 @@
 # Cookbook:: chef-lacework
 # Recipe:: config
 #
-# Copyright:: 2020, The Authors, All Rights Reserved.
+# Copyright:: 2020, Lacework, All Rights Reserved.
 directory '/var/lib/lacework/config' do
   recursive true
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,6 +2,6 @@
 # Cookbook:: chef-lacework
 # Recipe:: default
 #
-# Copyright:: 2020, The Authors, All Rights Reserved.
+# Copyright:: 2020, Lacework, All Rights Reserved.
 include_recipe 'chef-lacework::config'
 include_recipe 'chef-lacework::install'

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -2,7 +2,7 @@
 # Cookbook:: chef-lacework
 # Recipe:: install
 #
-# Copyright:: 2020, The Authors, All Rights Reserved.
+# Copyright:: 2020, Lacework, All Rights Reserved.
 
 case node['chef-lacework']['install_method']
 when 'install_script'

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -2,7 +2,7 @@
 # Cookbook:: chef-lacework
 # Recipe:: package
 #
-# Copyright:: 2020, The Authors, All Rights Reserved.
+# Copyright:: 2020, Lacework, All Rights Reserved.
 include_recipe 'chef-lacework::config'
 
 case node['platform_family']

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -2,7 +2,7 @@
 # Cookbook:: chef-lacework
 # Recipe:: repo
 #
-# Copyright:: 2020, The Authors, All Rights Reserved.
+# Copyright:: 2020, Lacework, All Rights Reserved.
 include_recipe 'chef-lacework::config'
 
 case node['platform_family']

--- a/spec/unit/recipes/_apt_spec.rb
+++ b/spec/unit/recipes/_apt_spec.rb
@@ -2,7 +2,7 @@
 # Cookbook:: chef-lacework
 # Spec:: _apt
 #
-# Copyright:: 2020, The Authors, All Rights Reserved.
+# Copyright:: 2020, Lacework, All Rights Reserved.
 
 require 'spec_helper'
 

--- a/spec/unit/recipes/_deb_spec.rb
+++ b/spec/unit/recipes/_deb_spec.rb
@@ -2,7 +2,7 @@
 # Cookbook:: chef-lacework
 # Spec:: _deb
 #
-# Copyright:: 2020, The Authors, All Rights Reserved.
+# Copyright:: 2020, Lacework, All Rights Reserved.
 
 require 'spec_helper'
 

--- a/spec/unit/recipes/_rpm_spec.rb
+++ b/spec/unit/recipes/_rpm_spec.rb
@@ -2,7 +2,7 @@
 # Cookbook:: chef-lacework
 # Spec:: _rpm
 #
-# Copyright:: 2020, The Authors, All Rights Reserved.
+# Copyright:: 2020, Lacework, All Rights Reserved.
 
 require 'spec_helper'
 

--- a/spec/unit/recipes/_script_spec.rb
+++ b/spec/unit/recipes/_script_spec.rb
@@ -2,7 +2,7 @@
 # Cookbook:: chef-lacework
 # Spec:: _script
 #
-# Copyright:: 2020, The Authors, All Rights Reserved.
+# Copyright:: 2020, Lacework, All Rights Reserved.
 
 require 'spec_helper'
 

--- a/spec/unit/recipes/_yum_spec.rb
+++ b/spec/unit/recipes/_yum_spec.rb
@@ -2,7 +2,7 @@
 # Cookbook:: chef-lacework
 # Spec:: _yum
 #
-# Copyright:: 2020, The Authors, All Rights Reserved.
+# Copyright:: 2020, Lacework, All Rights Reserved.
 
 require 'spec_helper'
 

--- a/spec/unit/recipes/config_spec.rb
+++ b/spec/unit/recipes/config_spec.rb
@@ -2,7 +2,7 @@
 # Cookbook:: chef-lacework
 # Spec:: config
 #
-# Copyright:: 2020, The Authors, All Rights Reserved.
+# Copyright:: 2020, Lacework, All Rights Reserved.
 
 require 'spec_helper'
 

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -2,7 +2,7 @@
 # Cookbook:: chef-lacework
 # Spec:: default
 #
-# Copyright:: 2020, The Authors, All Rights Reserved.
+# Copyright:: 2020, Lacework, All Rights Reserved.
 
 require 'spec_helper'
 

--- a/spec/unit/recipes/install_spec.rb
+++ b/spec/unit/recipes/install_spec.rb
@@ -2,7 +2,7 @@
 # Cookbook:: chef-lacework
 # Spec:: install
 #
-# Copyright:: 2020, The Authors, All Rights Reserved.
+# Copyright:: 2020, Lacework, All Rights Reserved.
 
 require 'spec_helper'
 

--- a/spec/unit/recipes/package_spec.rb
+++ b/spec/unit/recipes/package_spec.rb
@@ -2,7 +2,7 @@
 # Cookbook:: chef-lacework
 # Spec:: package
 #
-# Copyright:: 2020, The Authors, All Rights Reserved.
+# Copyright:: 2020, Lacework, All Rights Reserved.
 
 require 'spec_helper'
 

--- a/spec/unit/recipes/repo_spec.rb
+++ b/spec/unit/recipes/repo_spec.rb
@@ -2,7 +2,7 @@
 # Cookbook:: chef-lacework
 # Spec:: repo
 #
-# Copyright:: 2020, The Authors, All Rights Reserved.
+# Copyright:: 2020, Lacework, All Rights Reserved.
 
 require 'spec_helper'
 


### PR DESCRIPTION
This PR fixes the following documentation issues:

#### Copyright Header
Every file within the cookbook has been updated to properly cite Lacework as the copyright holder of the code within...

`# Copyright:: 2020, Lacework, All Rights Reserved`

#### Issues URL
The `metadata.rb` file has been updated to point to `'https://github.com/lacework/chef-lacework'` instead of `'https://github.com/scottford-lw/chef-lacework'`

#### Maintainers Email
The maintainer email for the cookbook has been updated to the `tech-ally@lacework.net` distribution list

### CLOSES

[#2](https://github.com/lacework/chef-lacework/issues/2)
[#3](https://github.com/lacework/chef-lacework/issues/3)
[#4](https://github.com/lacework/chef-lacework/issues/4)


Signed-off-by: Scott Ford <scott.ford@lacework.net>