### PR TITLE
fix(metadata.rb) Fix licensing in metadata.rb to Apache-2.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,8 +1,8 @@
 name 'chef-lacework'
 maintainer 'Lacework, Inc.'
 maintainer_email 'tech-ally@lacework.net'
-license 'All Rights Reserved'
-description 'Installs/Configures chef-lacework'
+license 'Apache-2.0'
+description 'Installs the Lacework agent for workload protection'
 version '0.1.0'
 chef_version '>= 13.0'
 %w( amazon centos fedora debian oracle redhat suse opensuse ubuntu ).each do |os|


### PR DESCRIPTION
This is a simple fix of the `metadata.rb` to update the licensing and add a description.

#### metadata.rb
- Updates license to `license 'Apache-2.0'`
- Updates description to `description 'Installs the Lacework agent for workload protection'`


Signed-off-by: Scott Ford <scott.ford@lacework.net>