### PR TITLE
chore(chef-client version) Bumping chef-client version to chef-client 15

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -15,7 +15,7 @@ provisioner:
   ## product_name and product_version specifies a specific Chef product and version to install.
   ## see the Chef documentation for more details: https://docs.chef.io/config_yml_kitchen.html
   product_name: chef
-  product_version: 13
+  product_version: 15
 
 verifier:
   name: inspec

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'tech-ally@lacework.net'
 license 'Apache-2.0'
 description 'Installs the Lacework agent for workload protection'
 version '0.1.0'
-chef_version '>= 13.0'
+chef_version '>= 15.0'
 %w( amazon centos fedora debian oracle redhat suse opensuse ubuntu ).each do |os|
   supports os
 end


### PR DESCRIPTION
This update sets the minimum chef-client version to chef-client 15 to get ready for the update to chef-client 16. Chef-client 13 and 14 are no longer supported by chef. 

Signed-off-by: Scott Ford <scott.ford@lacework.net>