### PR TITLE
Support Chef Infra Client 15

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -15,7 +15,7 @@ provisioner:
   ## product_name and product_version specifies a specific Chef product and version to install.
   ## see the Chef documentation for more details: https://docs.chef.io/config_yml_kitchen.html
   product_name: chef
-  product_version: 13
+  product_version: 15
 
 verifier:
   name: inspec

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'tech-ally@lacework.net'
 license 'Apache-2.0'
 description 'Installs the Lacework agent for workload protection'
 version '0.1.0'
-chef_version '>= 13.0'
+chef_version '>= 13.12'
 %w( amazon centos fedora debian oracle redhat suse opensuse ubuntu ).each do |os|
   supports os
 end


### PR DESCRIPTION
This PR is bumping the version of chef-client we use to test inside test-kitchen,
run a test of every supported platform and they all look good.

Additionally, I am just bumping the required version to the latest chef-client 13
release.

![tenor-179115946](https://user-images.githubusercontent.com/61525522/79886286-d0958300-83b5-11ea-9380-fff47dc87a37.gif)
