### PR TITLE
test(supermarket quality) Updating cookbook to meet Chef Supermarket quality

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,5 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Run cookstyle
-          command: cookstyle .
-      - run:
-          name: Run rspec
-          command: rspec .
+          name: Run delivery
+          command: delivery local all

--- a/.delivery/project.toml
+++ b/.delivery/project.toml
@@ -1,0 +1,9 @@
+[local_phases]
+unit = "rspec spec/"
+lint = 'cookstyle --display-cop-names --extra-details'
+syntax = "echo syntax checking with foodcritic has been replaced with cookstyle. skipping"
+provision = "echo skipping"
+deploy = "echo skipping"
+smoke = "echo skipping"
+functional = "echo skipping"
+cleanup = "echo skipping"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,127 @@
+# Contributing to Chef-Lacework Cookbook
+
+We're glad you want to contribute to the chef-lacework cookbook! The first step is the desire to improve the project.
+
+## Submitting Issues
+
+Not every contribution comes in the form of code. Submitting, confirming, and triaging issues is an important task for any project. At Lacework we use GitHub to track all project issues.
+
+## Contribution Process
+
+We have a 3 step process for contributions:
+
+1. Commit changes to a git branch, making sure to sign-off those changes
+2. Create a GitHub Pull Request for your change, following the instructions in the pull request template.
+3. Perform a [Code Review](#code-review-process) with the cookbook maintainers on the pull request.
+
+### Pull Request Requirements
+
+We strive to ensure high quality throughout the experience. In order to ensure this, all pull requests must meet these specifications:
+
+1. **Tests:** To ensure high quality code and protect against future regressions, we require all cookbook code to be tested in some way. This can be either unit testing with ChefSpec or integration testing with Test Kitchen / InSpec. See the TESTING.md file for additional information on testing in Chef cookbooks and feel free to ask if you need help with the testing process.
+2. **Green CI Tests:** We use [CircleCI](https://circleci.com/) to test all pull requests. We require these test runs to succeed on every pull request before being merged.
+
+### Code Review Process
+
+Code review takes place in GitHub pull requests. See [this article](https://help.github.com/articles/about-pull-requests/) if you're not familiar with GitHub Pull Requests.
+
+Once you open a pull request, cookbook maintainers will review your code using the built-in code review process in Github PRs. The process at this point is as follows:
+
+1. A cookbook maintainer will review your code and merge it if no changes are necessary. Your change will be merged into the cookbooks's `master` branch and will be noted in the cookbook's `CHANGELOG.md` at the time of release.
+2. If a maintainer has feedback or questions on your changes they they will set `request changes` in the review and provide an explanation.
+
+### Developer Certification of Origin (DCO)
+
+Licensing is very important to open source projects. It helps ensure the software continues to be available under the terms that the author desired.
+
+Lacework uses [the Apache 2.0 license](LICENSE) to strike a balance between open contribution and allowing you to use the software however you would like to.
+
+The license tells you what rights you have that are provided by the copyright holder. It is important that the contributor fully understands what rights they are licensing and agrees to them. Sometimes the copyright holder isn't the contributor, such as when the contributor is doing work on behalf of a company.
+
+The DCO is an attestation attached to every contribution made by every developer. In the commit message of the contribution, the developer simply adds a Signed-off-by statement and thereby agrees to the DCO, which you can find below or at <http://developercertificate.org/>.
+
+```
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the
+    best of my knowledge, is covered under an appropriate open
+    source license and I have the right under that license to
+    submit that work with modifications, whether created in whole
+    or in part by me, under the same open source license (unless
+    I am permitted to submit under a different license), as
+    Indicated in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including
+    all personal information I submit with it, including my
+    sign-off) is maintained indefinitely and may be redistributed
+    consistent with this project or the open source license(s)
+    involved.
+```
+
+#### DCO Sign-Off Methods
+
+The DCO requires a sign-off message in the following format appear on each commit in the pull request:
+
+```
+Signed-off-by: Scott Ford <scott.ford@lw.com>
+```
+
+The DCO text can either be manually added to your commit body, or you can add either **-s** or **--signoff** to your usual git commit commands. If you forget to add the sign-off you can also amend a previous commit with the sign-off by running **git commit --amend -s**. If you've pushed your changes to GitHub already you'll need to force push your branch after this with **git push -f**.
+
+## Using git
+
+You can copy the cookbook repository to your local workstation by running `git clone git://github.com/lacework/chef-lacework.git`.
+
+For collaboration purposes, it is best if you create a GitHub account and fork the repository to your own account. Once you do this you will be able to push your changes to your GitHub repository for others to see and use.
+
+If you have another repository in your GitHub account named the same as the cookbook, we suggest you suffix the repository with `-cookbook`.
+
+## Release Cycle
+
+The versioning for Chef Software Cookbook projects is X.Y.Z.
+
+- X is a major release, which may not be fully compatible with prior major releases
+- Y is a minor release, which adds both new features and bug fixes
+- Z is a patch release, which adds just bug fixes
+
+See the [Cookbook Versioning Policy](https://chef-community.github.io/cvp/) for more guidance on semantic versioning of cookbooks.
+
+Releases of this cookbook are generally performed after any bugfix / feature enhancement pull request merge. You can watch the Github repository for updates or watch the cookbook on the Supermarket to receive release notification e-mails.
+
+## Contribution Do's and Don't's
+
+Please do include tests for your contribution. If you need help, ask on the [chef-dev mailing list](https://discourse.chef.io/c/dev) or the [Chef Community Slack](https://community-slack.chef.io/). Not all platforms that a cookbook supports may be supported by Test Kitchen. Please provide evidence of testing your contribution if it isn't trivial so we don't have to duplicate effort in testing.
+
+Please do indicate new platform (families) or platform versions in the commit message, and update the relevant ticket.
+
+If a contribution adds new platforms or platform versions, indicate such in the body of the commit message(s), and update the relevant issues. When writing commit messages, it is helpful for others if you indicate the issue. For example: git commit -m '[ISSUE-1041] - Updated pool resource to correctly delete.'
+
+Please do ensure that your changes do not break or modify behavior for other platforms supported by the cookbook. For example if your changes are for Debian, make sure that they do not break on CentOS.
+
+Please do **not** modify the version number in the `metadata.rb`, a maintainer will select the appropriate version based on the release cycle information above.
+
+Please do **not** update the `CHANGELOG.md` for a new version. Not all changes to a cookbook may be merged and released in the same versions. A maintainer will update the `CHANGELOG.md` when releasing a new version of the cookbook.
+
+## Chef Community
+
+Chef is made possible by a strong community of developers and system administrators. If you have any questions or if you would like to get involved in the Chef community you can check out:
+
+- [Chef Mailing List](https://discourse.chef.io/)
+- [Chef Community Slack](https://community-slack.chef.io/)
+
+Also here are some additional pointers to some awesome Chef content:
+
+- [Chef Docs](https://docs.chef.io/)
+- [Learn Chef](https://learn.chef.io/)
+- [Chef Website](https://www.chef.sh/)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Lacework Agent Cookbook
 =========================
-[![lacework](https://circleci.com/gh/lacework/chef-lacework.svg?style=shield)](https://circleci.com/gh/lacework/chef-lacework)
+[![lacework](https://circleci.com/gh/lacework/chef-lacework.svg?style=shield)](https://circleci.com/gh/lacework/chef-lacework) [![Cookbook Version](https://img.shields.io/cookbook/v/chef-lacework.svg)](https://supermarket.chef.io/cookbooks/chef-lacework)
 
 [Lacework](https://lacework.com) is an end to end security platform designed to meet the demands of modern application deployments. The chef-lacework cookbook handles the installation and configuration of the Lacework agent.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,63 @@
+# Cookbook TESTING doc
+
+This document describes the process for testing the chef-lacework cookbook using Chef Workstation.
+
+## Testing Prerequisites
+
+A working Chef Workstation installation set as your system's default ruby. Chef Workstation can be downloaded at <https://downloads.chef.io/chef-workstation/>
+
+Hashicorp's [Vagrant](https://www.vagrantup.com/downloads.html) and Oracle's [Virtualbox](https://www.virtualbox.org/wiki/Downloads) for integration testing.
+
+## Local Delivery
+
+For consistent testing across the 100+ Chef managed community cookbooks we use the Delivery CLI tool and the local delivery mode. This allows us to remotely host a single [Delivery project.toml file](https://github.com/chef-cookbooks/community_cookbook_tools/blob/master/delivery/project.toml) that applies to all of our cookbooks.
+
+Delivery defines testing in phases and cookbooks utilize `lint`, `syntax`, and `unit` phases.
+
+To run an individual phase:
+
+```shell
+delivery local unit
+```
+
+To run all phases:
+
+```shell
+delivery local all
+```
+
+### lint stage
+
+The lint stage runs Ruby specific code linting using cookstyle (<https://github.com/chef/cookstyle>). Cookstyle offers a tailored RuboCop configuration enabling / disabling rules to better meet the needs of cookbook authors. Cookstyle ensures that projects with multiple authors have consistent code styling.
+
+### syntax stage
+
+The syntax stage runs Chef cookbook specific linting and syntax checks with Foodcritic (<http://www.foodcritic.io/>). Foodcritic tests for over 60 different cookbook conditions and helps authors avoid bad patterns in their cookbooks.
+
+### unit stage
+
+The unit stage runs unit testing with ChefSpec (<http://sethvargo.github.io/chefspec/>). ChefSpec is an extension of Rspec, specially formulated for testing Chef cookbooks. Chefspec compiles your cookbook code and converges the run in memory, without actually executing the changes. The user can write various assertions based on what they expect to have happened during the Chef run. Chefspec is very fast, and quick useful for testing complex logic as you can easily converge a cookbook many times in different ways.
+
+## Integration Testing
+
+Integration testing is performed by Test Kitchen. After a successful converge, tests are uploaded and ran out of band of Chef. Tests should be designed to ensure that a recipe has accomplished its goal.
+
+## Integration Testing using Vagrant
+
+Integration tests can be performed on a local workstation using either VirtualBox or VMWare as the virtualization hypervisor. To run tests against all available instances run:
+
+```shell
+chef exec kitchen test
+```
+
+To see a list of available test instances run:
+
+```shell
+chef exec kitchen list
+```
+
+To test specific instance run:
+
+```shell
+chef exec kitchen test INSTANCE_NAME
+```

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Lacework, Inc.'
 maintainer_email 'tech-ally@lacework.net'
 license 'Apache-2.0'
 description 'Installs the Lacework agent for workload protection'
-version '0.2.0'
+version '0.2.1'
 chef_version '>= 13.12'
 %w( amazon centos fedora debian oracle redhat suse opensuse ubuntu ).each do |os|
   supports os


### PR DESCRIPTION
This update is to address Chef Supermarket quality metrics. 

add `CONTRIBUTING.md`
add `TESTING.md`
add `.delivery/project.toml` 
update `.circleci/config.yaml` to exec `delivery local all`

bump cookbook version to `0.2.1`

Closes [#10](https://github.com/lacework/chef-lacework/issues/10)
Closes [#12 ](https://github.com/lacework/chef-lacework/issues/12)

Signed-off-by: Scott Ford <scott.ford@lacework.net>