### PR TITLE
feat: mark install.sh script execute as sensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the chef-lacework cookbook.
 
+# Unreleased
+
+- mark the `execute` block in `_script` from exposing secrets (outside of the process table) (@majormoses)
+
 # 0.1.0
 
 Initial release.

--- a/recipes/_script.rb
+++ b/recipes/_script.rb
@@ -10,6 +10,8 @@ end
 
 execute 'install.sh' do
   command "#{node['chef-lacework']['install_script']['dir']}/install.sh #{node['chef-lacework']['accesstoken']}"
+  # does not prevent it from being exposed in the process table
+  sensitive true
 
   not_if { ::File.exist?('/var/lib/lacework/datacollector') }
 end


### PR DESCRIPTION
Because exposing secrets are bad.