### PR TITLE
Document patterns for secure api keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Attributes
 ==========
 The following attributes affect the behavior of the of this cookbook, the lacework agent, and its configuration
 
-- `node['chef-lacework']['install_method'] = 'install_script'` - Sets the method to install the agent (options include: `install_script`, `yum`, `apt`, `rpm`, `deb`) 
+- `node['chef-lacework']['install_method'] = 'install_script'` - Sets the method to install the agent (options include: `install_script`, `yum`, `apt`, `rpm`, `deb`)
 - `node['chef-lacework']['config']['token'] = nil` - API token associated with your Lacework account. Docs for creating a new API token can be found [here](https://support.lacework.com/hc/en-us/articles/360036425594-Download-Agent-Installers-and-Get-the-Agent-Access-Token)
 - `node['chef-lacework']['config']['proxy_url'] = nil` - The Lacework agent can be configured to use a network proxy by adding proxy information to the configuration file or by creating a https_proxy environment variable. For more information, see [Required Connectivity, Proxies & Certificates](https://support.lacework.com/hc/en-us/articles/360008149354).
 - `node['chef-lacework']['config']['tags'] = []` - Specify name/value tags to categorize your agents, for example, identifying critical assets. For more information, see [Adding Agent Tags](https://support.lacework.com/hc/en-us/articles/360008466893).
@@ -72,9 +72,70 @@ The following attributes affect the behavior of the of this cookbook, the lacewo
 - `node['chef-lacework']['deb_package']['package_name'] = 'lacework_latest_amd64.deb'` - Name of `.deb` package to install on Debian/Ubuntu Linux
 - `node['chef-lacework']['deb_package']['shasum'] = ''` = sha256 sum of `.deb` package
 - `node['chef-lacework']['rpm_package']['url'] = ''` - URL to download `.rpm` package to install the Lacework agent
-- `node['chef-lacework']['rpm_package']['package_name'] = 'lacework-latest-1.x86_64.rpm'` - Name of `.rpm` package to install on RHEL/Centos/SUSE Linux 
-- `node['chef-lacework']['rpm_package']['shasum'] = '' ` = sha256 sum of `.rpm` package 
+- `node['chef-lacework']['rpm_package']['package_name'] = 'lacework-latest-1.x86_64.rpm'` - Name of `.rpm` package to install on RHEL/Centos/SUSE Linux
+- `node['chef-lacework']['rpm_package']['shasum'] = '' ` = sha256 sum of `.rpm` package
 
+
+Patterns for protecting Tokens
+=======
+
+Due to the way the cookbook is written we are exposing all the configuration as a namespace in chef. However there are sensitive properties such as the access key.
+
+Using `node.run_state` and a secret manager
+------
+
+If you are using a secret manager such as [aws ssm]() or [hashicorp valt]() this is probably the easiest and safest approach.
+
+Here is an example using aws ssm in your wrapper cookbook:
+```ruby
+directory '/var/lib/lacework/config' do
+  recursive true
+end
+​
+aws_ssm_parameter_store 'get lacework access token' do
+  path "/my/namespace/to/find/access_token"
+  return_key 'lacework_access_token'
+  with_decryption true
+  action :get_parameters
+end
+​
+config = node['chef-lacework']['config'].merge(
+  {
+    'tokens' => {
+      'AccessToken' => node.run_state['lacework_access_token']
+    }
+  }
+)
+​
+template '/var/lib/lacework/config/config.json' do
+  source 'config.json.erb'
+  cookbook 'chef-lacework'
+  variables(
+    config: config
+  )
+end
+​
+​
+# install
+include_recipe 'chef_lacework::install'
+```
+
+Using [Attribute Precedence](https://docs.chef.io/attribute_persistence/) to deny the client from writing the node object to the chef server
+------
+
+Please refer to the [upstream documentation](https://docs.chef.io/attribute_persistence/#attribute-blocklist) for further information
+
+In your `client.rb` file:
+```ruby
+# We don't have an automatic because there is currently no
+# ohai plugin that would pick this up. Should you create one
+# you should add a similar block. You can choose to only set
+# one of these but you run the risk of someone overriding and
+# accidentally exposing a key.
+blocked_default_attributes  = ['chef-lacework/accesstoken']
+blocked_normal_attributes   = %w(chef-lacework/accesstoken)
+blocked_override_attributes = %w(chef-lacework/accesstoken)
+```
 
 ## License and Copyright
 Copyright 2020, Lacework Inc.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The following attributes affect the behavior of the of this cookbook, the lacewo
 Patterns for protecting Tokens
 =======
 
-Due to the way the cookbook is written we are exposing all the configuration as a namespace in chef. However there are sensitive properties such as the access key.
+All of the configuration is exposed as a namespace in chef. There are sensitive properties such as the access key.
 
 Using `node.run_state` and a secret manager
 ------

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ template '/var/lib/lacework/config/config.json' do
   variables(
     config: config
   )
+  sensitive true
 end
 ​
 ​


### PR DESCRIPTION
The current documentation does not provide a lot of guidance on how to deliver sensitive keys and prevent them from being disclosed. While this does not look to solve any existing issues in the cookbook it aims to document the patterns that can be used without any modification. This focuses on two approaches:
- use a secret manager, write a local node state (which is not sent back to the chef server)
- use a node object and rely on chef/cinc client configuration to prevent these attributes from being written to the chef server
In both cases the biggest goal is to prevent anyone with read only chef access from being able to query the secret externally even if they would be able to run it locally if given permission on that server.