### PR TITLE
fix: Update Signing Key

### DIFF
--- a/recipes/_apt.rb
+++ b/recipes/_apt.rb
@@ -8,7 +8,7 @@ when 'ubuntu'
   apt_repository 'packages-lacework-prod' do
     uri "https://packages.lacework.net/DEB/#{node['platform']}/#{node['platform_version']}"
     arch 'amd64'
-    key ['18E76630']
+    key ['EE0CC692']
     keyserver 'keyserver.ubuntu.com'
     components ['main']
     action :add
@@ -19,7 +19,7 @@ when 'debian'
   apt_repository 'packages-lacework-prod' do
     uri "https://packages.lacework.net/DEB/#{node['platform']}/#{node['platform_version'].to_i}"
     arch 'amd64'
-    key ['18E76630']
+    key ['EE0CC692']
     keyserver 'keyserver.ubuntu.com'
     components ['main']
     action :add


### PR DESCRIPTION
### Issue 
Github:https://github.com/lacework/chef-lacework/issues/23 
JIRA: https://lacework.atlassian.net/browse/ALLY-696

### Description
Correct gpg key.
Lacework support docs -> https://support.lacework.com/hc/en-us/articles/4402737815443-Update-the-public-signing-key-for-agent-installs-using-APT-or-YUM

Signed-off-by: Darren Murray <darren.murray@lacework.net>